### PR TITLE
Display impl for Atom now padded to 8 bytes hex.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,6 @@ impl PartialEq<str> for Atom {
 
 impl fmt::Display for Atom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "a:{:x}", self.value)
+        write!(f, "a:{:016x}", self.value)
     }
 }


### PR DESCRIPTION
The Display output for Atom was previously unpadded hexadecimal. As the values of Atoms are of consistent length, this change pads the display to 8 bytes of hexadecimal.